### PR TITLE
Replace String.replaceAll with String.replace

### DIFF
--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
@@ -112,10 +112,10 @@ public class DiscordBot {
                     this.messageCreateEvent.getChannel().sendMessage("Players : " + server.getPlayerManager().getPlayerList().size() + "/" + server.getPlayerManager().getMaxPlayerCount() + "\n\n" + playerlist);
                 }
                 this.lastMessageD = this.config.discordToMinecraft.message
-                        .replaceAll("%player", this.messageCreateEvent.getMessageAuthor().getDisplayName());
+                        .replace("%player", this.messageCreateEvent.getMessageAuthor().getDisplayName());
                 String string_message = EmojiParser.parseToAliases(this.messageCreateEvent.getMessageContent());
                 for (FDLink.Config.EmojiEntry emojiEntry : this.config.emojiMap) {
-                    string_message = string_message.replaceAll("<" + emojiEntry.id + ">", emojiEntry.name);
+                    string_message = string_message.replace("<" + emojiEntry.id + ">", emojiEntry.name);
                 }
                 if (this.config.minecraftToDiscord.booleans.minecraftToDiscordTag) {
                     for (User user : this.api.getCachedUsers()) {
@@ -125,18 +125,18 @@ public class DiscordBot {
                         if(this.config.minecraftToDiscord.booleans.minecraftToDiscordDiscriminator){
                             string_discriminator = "#" + user.getDiscriminator();
                         }
-                        string_message = string_message.replaceAll("<@!" + user.getIdAsString() + ">", "@" + user.getDisplayName(discordServer) + string_discriminator);
+                        string_message = string_message.replace("<@!" + user.getIdAsString() + ">", "@" + user.getDisplayName(discordServer) + string_discriminator);
                         if (user.getNickname(discordServer).isPresent() && this.config.discordToMinecraft.pingLongVersion) {
-                            string_message = string_message.replaceAll("@" + user.getName(), "@" + user.getDisplayName(discordServer) + "(" + user.getName() + string_discriminator + ")");
+                            string_message = string_message.replace("@" + user.getName(), "@" + user.getDisplayName(discordServer) + "(" + user.getName() + string_discriminator + ")");
                         }
                     }
                 }
                 Style style = Style.EMPTY;
                 if (!this.messageCreateEvent.getMessageAttachments().isEmpty()) {
-                    this.lastMessageD = this.lastMessageD.replaceAll("%message", string_message + " (Click to open attachment URL)");
+                    this.lastMessageD = this.lastMessageD.replace("%message", string_message + " (Click to open attachment URL)");
                     style = style.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, this.messageCreateEvent.getMessageAttachments().get(0).getUrl().toString()));
                 } else {
-                    this.lastMessageD = this.lastMessageD.replaceAll("%message", string_message);
+                    this.lastMessageD = this.lastMessageD.replace("%message", string_message);
                 }
                 server.getPlayerManager().sendToAll(new GameMessageS2CPacket(new LiteralText(this.lastMessageD).setStyle(style), MessageType.CHAT, UUID.randomUUID()));
 

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
@@ -185,11 +185,13 @@ public class MinecraftToDiscordHandler {
                 return;
             }
         }
+/*
         if (text instanceof TranslatableText) {
             DiscordBot.LOGGER.error("[FDLink] Unhandled text \"{}\":{}", ((TranslatableText) text).getKey(), text.getString());
         } else {
             DiscordBot.LOGGER.error("[FDLink] Unhandled text \"{}\"", text.getString());
         }
+*/
     }
 
     public static class TextHandler {


### PR DESCRIPTION
Note: I barely know any java, however...

String.replaceAll allows regular expressions, where String.replace does
not. String.replaceAll should not be used for user-provided data, as
the simple text "$1" throws an exception, which is not caught here, and
crashes the entire bot/server.

Several other strings also throw uncaught exceptions, eg: $$, $test, $,
etc.

String.replace still replaces all instances of the needle text in the
haystack because java is intuitive(TM).

This should fix https://github.com/arthurbambou/Fabric---Discord-Link/issues/88 along with several other bugs that have not, as of yet,
been found by users, but are trivial to find. (eg: changing your name to
include $ should crash the bot every time you say anything).

EDIT: Tested working. Probably not a full fix, but it passes my tests. You're welcome.