### PR TITLE
Created a more fine grained control over chat and log channel using the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ After downloading the latest version, just drop the jar into the mods folder.
 ### Building from source
 1. Download the repository
 2. Follow [this guide](https://fabricmc.net/wiki/tutorial:setup) to setup gradle and build the project
-3. Drop the jar into the fabric mod folder
+3. Drop the resulting jar into the fabric mod folder
 
 ### Acquiring and configuring a Discord Bot
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ After downloading the latest version, just drop the jar into the mods folder.
 ### Configuring Fabric-Discord-Link
 1. Start your minecraft server once to let Fabric-Discord-Link generate it's default config `<fdlink.json>`
 2. Turn your server back off
-2. Copy your Bots Token from the Discord Developer Portal and paste it into the empty double quotes behind "token" in the config
+2. Copy your Bots Token from the Discord Developer Portal and paste it into the empty double quotes behind `<"token">` in the config
 3. Obtain the channel IDs of the channels that you want your bot to function in (these can be from separate discord servers). To do this, you need to enable Discords Developer mode in your Discord Settings under `<Appearance>`. Afterwards you can right click channels and select `<Copy ID>` at the bottom
 3. Paste the Discord Chat and/or Log Channel's IDs into the appropriate locations in the config. The IDs need to be in double quotes inside the brackets. If you have more than one Chat or Log Channel you need to separate the channel IDs inside the brackets with commas (no comma behind the last ID)
 4. Configure the other settings in the config to your liking

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Fabric-Discord-Link is a lightweight server mod for the fabric mod loader which 
 ## Installation
 
 ### Dependencies
-Fabric-Discord-Link requires Fabric API to work. [The Fabric-API](https://github.com/FabricMC/fabric/releases) jar needs to be in your mod folder.
+Fabric-Discord-Link requires Fabric API to work. The [Fabric-API](https://github.com/FabricMC/fabric/releases) jar needs to be in your mod folder.
 
 ### Obtaining the binaries
 The release binaries are available in the [releases](https://github.com/arthurbambou/Fabric---Discord-Link/releases) section or on [curseforge](https://www.curseforge.com/minecraft/mc-mods/fabric-discord-link). 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
 # Fabric<->Discord Link
+
+Fabric-Discord-Link is a lightweight server mod for the fabric mod loader which links your minecraft server and it's chat to a discord server via your very own discord bot.
+
+## Features
+* Configure a Chat channel to chat between your minecraft world and a discord channel
+* Configure a Log channel to show server messages and admin actions
+* Use commands to get live information on your Minecraft Servers status:
+    * !status - Shows number of players that are online right now and the server's uptime
+    * !uptime - Shows server's uptime
+    * !playercount - Shows number of online players / server player maximum
+    * !playerlist - Shows list of names of online players
+* Configure custom messages for
+    * Server starting
+    * Server started
+    * Server stopping
+    * Server stopped
+    * Player joining server
+    * Player joining server with a different name to their known name
+    * Player leaving server
+    * Player making advancement
+    * Player completing challenge
+    * Player reaching goal
+    * Prefix for death messages (i.e. emojis like :skull_crossbones:)
+    * Postfix for death messages
+* Configure Emojis
+* Configure how messages from Discord appear in the ingame chat (default is senders name in brackets to distinguish from ingame player's messages)
+
+## Installation
+
+### Dependencies
+Fabric-Discord-Link requires Fabric API to work. [The Fabric-API](https://github.com/FabricMC/fabric/releases) jar needs to be in your mod folder.
+
+### Obtaining the binaries
+The release binaries are available in the [releases](https://github.com/arthurbambou/Fabric---Discord-Link/releases) section or on [curseforge](https://www.curseforge.com/minecraft/mc-mods/fabric-discord-link). 
+
+After downloading the latest version, just drop the jar into the mods folder.
+
+### Building from source
+1. Download the repository
+2. Follow [this guide](https://fabricmc.net/wiki/tutorial:setup) to setup gradle and build the project
+3. Drop the jar into the fabric mod folder
+
+### Acquiring and configuring a Discord Bot
+
+1. Go to the [discord developer portal](https://discord.com/developers/applications) and register a new Application
+2. Register a new Bot for the application in the `<Bot>` tab to the left
+3. Toogle `<Server Members Intent>` to on under `<Priviledged Gateway Intents>` after creating a bot
+4. In the `<OAuth2>` Tab to the left, select the `<Bot>` option under `<Scopes>` and select the options `<View Channels>` and `<Send Messages>` 
+5. Copy the URL generated under `<Scopes>` and open it in a new tab to add the bot to your discord server
+
+### Configuring Fabric-Discord-Link
+1. Start your minecraft server once to let Fabric-Discord-Link generate it's default config `<fdlink.json>`
+2. Turn your server back off
+2. Copy your Bots Token from the Discord Developer Portal and paste it into the empty double quotes behind "token" in the config
+3. Obtain the channel IDs of the channels that you want your bot to function in (these can be from separate discord servers). To do this, you need to enable Discords Developer mode in your Discord Settings under `<Appearance>`. Afterwards you can right click channels and select `<Copy ID>` at the bottom
+3. Paste the Discord Chat and/or Log Channel's IDs into the appropriate locations in the config. The IDs need to be in double quotes inside the brackets. If you have more than one Chat or Log Channel you need to separate the channel IDs inside the brackets with commas (no comma behind the last ID)
+4. Configure the other settings in the config to your liking
+5. Restart your server

--- a/src/main/java/fr/arthurbambou/fdlink/FDLink.java
+++ b/src/main/java/fr/arthurbambou/fdlink/FDLink.java
@@ -99,8 +99,8 @@ public class FDLink implements DedicatedServerModInitializer {
 				if (config.minecraftToDiscord == null) {
 					config.minecraftToDiscord = DefaultConfig.minecraftToDiscord;
 				}
-				if (config.minecraftToDiscord.booleans == null) {
-					config.minecraftToDiscord.booleans = DefaultConfig.minecraftToDiscord.booleans;
+				if (config.minecraftToDiscord.general == null) {
+					config.minecraftToDiscord.general = DefaultConfig.minecraftToDiscord.general;
 				}
 				if (config.minecraftToDiscord.messages == null) {
 					config.minecraftToDiscord.messages = DefaultConfig.minecraftToDiscord.messages;
@@ -134,6 +134,12 @@ public class FDLink implements DedicatedServerModInitializer {
 				}
 				if (config.minecraftToDiscord.messages.playerJoinedRenamed == null) {
 					config.minecraftToDiscord.messages.playerJoinedRenamed = DefaultConfig.minecraftToDiscord.messages.playerJoinedRenamed;
+				}
+				if (config.minecraftToDiscord.chatChannels == null) {
+					config.minecraftToDiscord.chatChannels = DefaultConfig.minecraftToDiscord.chatChannels;
+				}
+				if (config.minecraftToDiscord.logChannels == null) {
+					config.minecraftToDiscord.logChannels = DefaultConfig.minecraftToDiscord.logChannels;
 				}
 				if (config.emojiMap == null) {
 					config.emojiMap = DefaultConfig.emojiMap;
@@ -171,8 +177,14 @@ public class FDLink implements DedicatedServerModInitializer {
 		}
 
 		public class MinecraftToDiscord {
+			public MinecraftToDiscordGeneral general = new MinecraftToDiscordGeneral();
 			public MinecraftToDiscordMessage messages = new MinecraftToDiscordMessage();
-			public MinecraftToDiscordBooleans booleans = new MinecraftToDiscordBooleans();
+			public MinecraftToDiscordChatChannel chatChannels = new MinecraftToDiscordChatChannel();
+			public MinecraftToDiscordLogChannel logChannels = new MinecraftToDiscordLogChannel();
+		}
+
+		public class MinecraftToDiscordGeneral {
+			public boolean enableDebugLogs = false;
 		}
 
 		public class MinecraftToDiscordMessage {
@@ -188,7 +200,7 @@ public class FDLink implements DedicatedServerModInitializer {
 			public String advancementGoal = "%player has made the goal %advancement";
 		}
 
-		public class MinecraftToDiscordBooleans {
+		public class MinecraftToDiscordChatChannel {
 			public boolean serverStartingMessage = true;
 			public boolean serverStartMessage = true;
 			public boolean serverStopMessage = true;
@@ -199,11 +211,31 @@ public class FDLink implements DedicatedServerModInitializer {
 			public boolean playerMessages = true;
 			public boolean joinAndLeaveMessages = true;
 			public boolean advancementMessages = true;
+			public boolean challengeCompletedMessages = true;
+			public boolean goalReachedMessages = true;
 			public boolean deathMessages = true;
 			public boolean sendMeCommand = true;
 			public boolean sendSayCommand = true;
+			public boolean adminMessages = false;
+		}
+
+		public class MinecraftToDiscordLogChannel {
+			public boolean serverStartingMessage = true;
+			public boolean serverStartMessage = true;
+			public boolean serverStopMessage = true;
+			public boolean serverStoppingMessage = true;
+			public boolean customChannelDescription = false;
+			public boolean minecraftToDiscordTag = false;
+			public boolean minecraftToDiscordDiscriminator = false;
+			public boolean playerMessages = false;
+			public boolean joinAndLeaveMessages = true;
+			public boolean advancementMessages = false;
+			public boolean challengeCompletedMessages = false;
+			public boolean goalReachedMessages = true;
+			public boolean deathMessages = false;
+			public boolean sendMeCommand = true;
+			public boolean sendSayCommand = true;
 			public boolean adminMessages = true;
-			public boolean enableDebugLogs = false;
 		}
 
 		public class DiscordToMinecraft {

--- a/src/main/java/fr/arthurbambou/fdlink/FDLink.java
+++ b/src/main/java/fr/arthurbambou/fdlink/FDLink.java
@@ -213,7 +213,7 @@ public class FDLink implements DedicatedServerModInitializer {
 			public boolean serverStartMessage = true;
 			public boolean serverStopMessage = true;
 			public boolean serverStoppingMessage = true;
-//			public boolean customChannelDescription = false;
+			public boolean customChannelDescription = false;
 			public boolean minecraftToDiscordTag = false;
 			public boolean minecraftToDiscordDiscriminator = false;
 			public boolean playerMessages = true;
@@ -232,7 +232,7 @@ public class FDLink implements DedicatedServerModInitializer {
 			public boolean serverStartMessage = true;
 			public boolean serverStopMessage = true;
 			public boolean serverStoppingMessage = true;
-//			public boolean customChannelDescription = false;
+			public boolean customChannelDescription = false;
 			public boolean minecraftToDiscordTag = false;
 			public boolean minecraftToDiscordDiscriminator = false;
 			public boolean playerMessages = false;

--- a/src/main/java/fr/arthurbambou/fdlink/FDLink.java
+++ b/src/main/java/fr/arthurbambou/fdlink/FDLink.java
@@ -135,6 +135,12 @@ public class FDLink implements DedicatedServerModInitializer {
 				if (config.minecraftToDiscord.messages.playerJoinedRenamed == null) {
 					config.minecraftToDiscord.messages.playerJoinedRenamed = DefaultConfig.minecraftToDiscord.messages.playerJoinedRenamed;
 				}
+				if (config.minecraftToDiscord.messages.deathMsgPrefix == null) {
+					config.minecraftToDiscord.messages.deathMsgPrefix = DefaultConfig.minecraftToDiscord.messages.deathMsgPrefix;
+				}
+				if (config.minecraftToDiscord.messages.deathMsgPostfix == null) {
+					config.minecraftToDiscord.messages.deathMsgPostfix = DefaultConfig.minecraftToDiscord.messages.deathMsgPostfix;
+				}
 				if (config.minecraftToDiscord.chatChannels == null) {
 					config.minecraftToDiscord.chatChannels = DefaultConfig.minecraftToDiscord.chatChannels;
 				}
@@ -196,8 +202,10 @@ public class FDLink implements DedicatedServerModInitializer {
 			public String playerJoinedRenamed = "%new (formerly known as %old) joined the game";
 			public String playerLeft = "%player left the game";
 			public String advancementTask = "%player has made the advancement %advancement";
-			public String advancementChallenge = "%player has made the challenge %advancement";
-			public String advancementGoal = "%player has made the goal %advancement";
+			public String advancementChallenge = "%player has completed the challenge %advancement";
+			public String advancementGoal = "%player has reached the goal %advancement";
+			public String deathMsgPrefix = "";
+			public String deathMsgPostfix = "";
 		}
 
 		public class MinecraftToDiscordChatChannel {
@@ -205,14 +213,14 @@ public class FDLink implements DedicatedServerModInitializer {
 			public boolean serverStartMessage = true;
 			public boolean serverStopMessage = true;
 			public boolean serverStoppingMessage = true;
-			public boolean customChannelDescription = false;
+//			public boolean customChannelDescription = false;
 			public boolean minecraftToDiscordTag = false;
 			public boolean minecraftToDiscordDiscriminator = false;
 			public boolean playerMessages = true;
 			public boolean joinAndLeaveMessages = true;
 			public boolean advancementMessages = true;
-			public boolean challengeCompletedMessages = true;
-			public boolean goalReachedMessages = true;
+			public boolean challengeMessages = true;
+			public boolean goalMessages = true;
 			public boolean deathMessages = true;
 			public boolean sendMeCommand = true;
 			public boolean sendSayCommand = true;
@@ -224,14 +232,14 @@ public class FDLink implements DedicatedServerModInitializer {
 			public boolean serverStartMessage = true;
 			public boolean serverStopMessage = true;
 			public boolean serverStoppingMessage = true;
-			public boolean customChannelDescription = false;
+//			public boolean customChannelDescription = false;
 			public boolean minecraftToDiscordTag = false;
 			public boolean minecraftToDiscordDiscriminator = false;
 			public boolean playerMessages = false;
 			public boolean joinAndLeaveMessages = true;
 			public boolean advancementMessages = false;
-			public boolean challengeCompletedMessages = false;
-			public boolean goalReachedMessages = false;
+			public boolean challengeMessages = false;
+			public boolean goalMessages = false;
 			public boolean deathMessages = true;
 			public boolean sendMeCommand = true;
 			public boolean sendSayCommand = true;

--- a/src/main/java/fr/arthurbambou/fdlink/FDLink.java
+++ b/src/main/java/fr/arthurbambou/fdlink/FDLink.java
@@ -188,10 +188,10 @@ public class FDLink implements DedicatedServerModInitializer {
 		}
 
 		public class MinecraftToDiscordMessage {
-			public String serverStarting = "Server is starting !";
-			public String serverStarted = "Server Started";
+			public String serverStarting = "Server is starting!";
+			public String serverStarted = "Server Started.";
 			public String serverStopping = "Server is stopping!";
-			public String serverStopped = "Server Stopped";
+			public String serverStopped = "Server Stopped.";
 			public String playerJoined = "%player joined the game";
 			public String playerJoinedRenamed = "%new (formerly known as %old) joined the game";
 			public String playerLeft = "%player left the game";
@@ -231,8 +231,8 @@ public class FDLink implements DedicatedServerModInitializer {
 			public boolean joinAndLeaveMessages = true;
 			public boolean advancementMessages = false;
 			public boolean challengeCompletedMessages = false;
-			public boolean goalReachedMessages = true;
-			public boolean deathMessages = false;
+			public boolean goalReachedMessages = false;
+			public boolean deathMessages = true;
 			public boolean sendMeCommand = true;
 			public boolean sendSayCommand = true;
 			public boolean adminMessages = true;

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
@@ -189,14 +189,14 @@ public class DiscordBot {
         if (this.minecraftToDiscordHandler != null) this.minecraftToDiscordHandler.handleTexts(text);
     }
 
-    public List<CompletableFuture<Message>> sendToAllChannels(String message) {
-        List<CompletableFuture<Message>> requests = new ArrayList<>();
-        if (this.hasLogChannels) {
-            requests.add(sendToLogChannels(message));
-        }
-        requests.add(sendToChatChannels(message));
-        return requests;
-    }
+//    public List<CompletableFuture<Message>> sendToAllChannels(String message) {
+//        List<CompletableFuture<Message>> requests = new ArrayList<>();
+//        if (this.hasLogChannels) {
+//            requests.add(sendToLogChannels(message));
+//        }
+//        requests.add(sendToChatChannels(message));
+//        return requests;
+//    }
 
     /**
      * This method will send to chat channel as fallback if no log channel is present

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
@@ -107,11 +107,12 @@ public class DiscordBot {
         ServerLifecycleEvents.SERVER_STOPPED.register((server -> {
             if (this.config.minecraftToDiscord.chatChannels.serverStopMessage || this.config.minecraftToDiscord.logChannels.serverStopMessage) {
                 ArrayList<CompletableFuture<Message>> requests = new ArrayList<>();
-                if(this.config.minecraftToDiscord.chatChannels.serverStopMessage) requests.add(sendToChatChannels(config.minecraftToDiscord.messages.serverStopped));
-                if(this.config.minecraftToDiscord.logChannels.serverStopMessage) requests.add(sendToLogChannels(config.minecraftToDiscord.messages.serverStopped));
-                Iterator<CompletableFuture<Message>> requestsIterator = requests.iterator();
-                while (requestsIterator.hasNext()) {
-                    while (!requestsIterator.next().isDone()) {
+                if(this.config.minecraftToDiscord.chatChannels.serverStopMessage && this.hasChatChannels) requests.add(sendToChatChannels(config.minecraftToDiscord.messages.serverStopped));
+                if(this.config.minecraftToDiscord.logChannels.serverStopMessage && this.hasLogChannels) requests.add(sendToLogChannels(config.minecraftToDiscord.messages.serverStopped));
+//                Iterator<CompletableFuture<Message>> requestsIterator = requests.iterator();
+//               while (requestsIterator.hasNext()) {
+                for (CompletableFuture<Message> request : requests){    
+                    while (!request.isDone()) {
                         if (this.config.minecraftToDiscord.general.enableDebugLogs) LOGGER.info("Request is not done yet!");
                     }
                 }

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
@@ -5,7 +5,6 @@ import fr.arthurbambou.fdlink.FDLink;
 import fr.arthurbambou.fdlink.discordstuff.todiscord.MinecraftToDiscordHandler;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents.ServerStopping;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.MessageType;
 import net.minecraft.network.packet.s2c.play.GameMessageS2CPacket;

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
@@ -23,7 +23,7 @@ import org.javacord.api.event.message.MessageCreateEvent;
 import org.javacord.api.listener.message.MessageCreateListener;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -106,11 +106,12 @@ public class DiscordBot {
         });
         ServerLifecycleEvents.SERVER_STOPPED.register((server -> {
             if (this.config.minecraftToDiscord.chatChannels.serverStopMessage || this.config.minecraftToDiscord.logChannels.serverStopMessage) {
-                List<CompletableFuture<Message>> requests = new ArrayList<>();
+                ArrayList<CompletableFuture<Message>> requests = new ArrayList<>();
                 if(this.config.minecraftToDiscord.chatChannels.serverStopMessage) requests.add(sendToChatChannels(config.minecraftToDiscord.messages.serverStopped));
                 if(this.config.minecraftToDiscord.logChannels.serverStopMessage) requests.add(sendToLogChannels(config.minecraftToDiscord.messages.serverStopped));
-                for (CompletableFuture<Message> request : requests) {
-                    while (!request.isDone()) {
+                Iterator<CompletableFuture<Message>> requestsIterator = requests.iterator();
+                while (requestsIterator.hasNext()) {
+                    while (!requestsIterator.next().isDone()) {
                         if (this.config.minecraftToDiscord.general.enableDebugLogs) LOGGER.info("Request is not done yet!");
                     }
                 }
@@ -198,7 +199,7 @@ public class DiscordBot {
 
                 this.hasReceivedMessage = false;
             }
-/*             if ((this.hasChatChannels || this.hasLogChannels) && (this.config.minecraftToDiscord.chatChannels.customChannelDescription ||  this.config.minecraftToDiscord.logChannels.customChannelDescription) && ((Util.getMeasuringTimeMs()/1000) % 10) == 0) {
+             if ((this.hasChatChannels || this.hasLogChannels) && (this.config.minecraftToDiscord.chatChannels.customChannelDescription ||  this.config.minecraftToDiscord.logChannels.customChannelDescription) && ((Util.getMeasuringTimeMs()/1000) % 300 == 0)) {
                 int totalUptimeSeconds = (int) (Util.getMeasuringTimeMs() - this.startTime) / 1000;
                 final int uptimeH = totalUptimeSeconds / 3600 ;
                 final int uptimeM = (totalUptimeSeconds % 3600) / 60;
@@ -224,7 +225,7 @@ public class DiscordBot {
                     )));
                     }
                 }
-            } */
+            }
         }));
     }
 

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
@@ -44,12 +44,6 @@ public class DiscordBot {
     public DiscordBot(String token, FDLink.Config config) {
         this.lastMessageD = "";
 
-        ArrayList<String> commands = new ArrayList<>();
-        commands.add("!playercount");
-        commands.add("!playerlist");
-        commands.add("!uptime");
-        commands.add("!status");
-
         if (token == null) {
             FDLink.regenConfig();
             return;

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
@@ -88,8 +88,8 @@ public class DiscordBot {
 
         if (this.config.minecraftToDiscord.chatChannels.serverStartingMessage || this.config.minecraftToDiscord.logChannels.serverStartingMessage) {
             ServerLifecycleEvents.SERVER_STARTING.register(minecraftServer -> {
-                if (this.config.minecraftToDiscord.chatChannels.serverStoppingMessage) sendToChatChannels(config.minecraftToDiscord.messages.serverStarting);
-                if (this.config.minecraftToDiscord.logChannels.serverStoppingMessage) sendToLogChannels(config.minecraftToDiscord.messages.serverStarting);
+                if (this.config.minecraftToDiscord.chatChannels.serverStartingMessage) sendToChatChannels(config.minecraftToDiscord.messages.serverStarting);
+                if (this.config.minecraftToDiscord.logChannels.serverStartingMessage) sendToLogChannels(config.minecraftToDiscord.messages.serverStarting);
             });
         }
 

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
@@ -31,7 +31,9 @@ public final class MinecraftToDiscordHandler {
         // Chat messages
         registerTextHandler(new TextHandler("chat.type.text", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.booleans.playerMessages) {
+            String chatMessage = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
+            String logMessage = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
+            if (this.config.minecraftToDiscord.chatChannels.playerMessages || this.config.minecraftToDiscord.logChannels.playerMessages) {
                 String playerName = message.split("> ")[0];
                 playerName = playerName.substring(1);
                 String fixedName = adaptUsernameToDiscord(playerName);
@@ -39,8 +41,13 @@ public final class MinecraftToDiscordHandler {
                 for (FDLink.Config.EmojiEntry emojiEntry : this.config.emojiMap) {
                     message = message.replaceAll(emojiEntry.name, "<" + emojiEntry.id + ">");
                 }
-
-                if (this.config.minecraftToDiscord.booleans.minecraftToDiscordTag) {
+                if(!this.config.minecraftToDiscord.chatChannels.minecraftToDiscordTag){
+                    chatMessage = message;
+                }
+                if(!this.config.minecraftToDiscord.logChannels.minecraftToDiscordTag){
+                    logMessage = message;
+                }
+                if (this.config.minecraftToDiscord.chatChannels.minecraftToDiscordTag ||  this.config.minecraftToDiscord.logChannels.minecraftToDiscordTag) {
                     for (User user : this.api.getCachedUsers()) {
                         ServerChannel serverChannel = (ServerChannel) this.api.getServerChannels().toArray()[0];
                         Server server = serverChannel.getServer();
@@ -55,107 +62,161 @@ public final class MinecraftToDiscordHandler {
                                     .replaceAll("@" + user.getNickname(server).get().toLowerCase(), user.getMentionTag());
                         }
                     }
+                    if(this.config.minecraftToDiscord.chatChannels.minecraftToDiscordTag){
+                        chatMessage = message;
+                    }
+                    if(this.config.minecraftToDiscord.logChannels.minecraftToDiscordTag){
+                        logMessage = message;
+                    }
                 }
-                this.discordBot.sendToAllChannels(message);
+                if(this.config.minecraftToDiscord.chatChannels.playerMessages){
+                this.discordBot.sendToChatChannels(chatMessage);
+                }else if(this.config.minecraftToDiscord.logChannels.playerMessages){
+                this.discordBot.sendToLogChannels(logMessage);
+                }
             }
         }));
 
         // /me command
         registerTextHandler(new TextHandler("chat.type.emote", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.booleans.sendMeCommand) {
-                this.discordBot.sendToAllChannels(message);
+            if (this.config.minecraftToDiscord.chatChannels.sendMeCommand) {
+                this.discordBot.sendToChatChannels(message);
+            }
+            if (this.config.minecraftToDiscord.logChannels.sendMeCommand) {
+                this.discordBot.sendToLogChannels(message);
             }
         }));
 
         // /say command
         registerTextHandler(new TextHandler("chat.type.announcement", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.booleans.sendSayCommand) {
-                this.discordBot.sendToAllChannels(message);
+            if (this.config.minecraftToDiscord.chatChannels.sendSayCommand) {
+                this.discordBot.sendToChatChannels(message);
+            }
+            if (this.config.minecraftToDiscord.logChannels.sendSayCommand) {
+                this.discordBot.sendToLogChannels(message);
             }
         }));
 
         // Advancement task
         registerTextHandler(new TextHandler("chat.type.advancement.task", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.booleans.advancementMessages) {
+            if (this.config.minecraftToDiscord.chatChannels.advancementMessages || this.config.minecraftToDiscord.logChannels.advancementMessages) {
                 String[] args = message.split(" has made the advancement ");
                 message = this.config.minecraftToDiscord.messages.advancementTask
                         .replace("%player", adaptUsernameToDiscord(args[0]))
                         .replace("%advancement", args[1]);
-                this.discordBot.sendToAllChannels(message);
+                if (this.config.minecraftToDiscord.chatChannels.advancementMessages) {
+                        this.discordBot.sendToChatChannels(message);
+                 }
+                if (this.config.minecraftToDiscord.logChannels.advancementMessages) {
+                        this.discordBot.sendToLogChannels(message);
+                }
             }
         }));
 
         // Advancement challenge
         registerTextHandler(new TextHandler("chat.type.advancement.challenge", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.booleans.advancementMessages) {
+            if (this.config.minecraftToDiscord.chatChannels.challengeCompletedMessages || this.config.minecraftToDiscord.logChannels.challengeCompletedMessages) {
                 String[] args = message.split(" has completed the challenge ");
                 message = this.config.minecraftToDiscord.messages.advancementChallenge
                         .replace("%player", adaptUsernameToDiscord(args[0]))
                         .replace("%advancement", args[1]);
-                this.discordBot.sendToAllChannels(message);
+                if (this.config.minecraftToDiscord.chatChannels.challengeCompletedMessages) {
+                    this.discordBot.sendToChatChannels(message);
+                }
+                if (this.config.minecraftToDiscord.logChannels.challengeCompletedMessages) {
+                    this.discordBot.sendToLogChannels(message);
+                }
             }
         }));
 
         // Advancement goal
         registerTextHandler(new TextHandler("chat.type.advancement.goal", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.booleans.advancementMessages) {
+            if (this.config.minecraftToDiscord.chatChannels.goalReachedMessages || this.config.minecraftToDiscord.logChannels.goalReachedMessages) {
                 String[] args = message.split(" has reached the goal ");
                 message = this.config.minecraftToDiscord.messages.advancementGoal
                         .replace("%player", adaptUsernameToDiscord(args[0]))
                         .replace("%advancement", args[1]);
-                this.discordBot.sendToAllChannels(message);
+                if (this.config.minecraftToDiscord.chatChannels.goalReachedMessages) {
+                    this.discordBot.sendToChatChannels(message);
+                }
+                if (this.config.minecraftToDiscord.logChannels.goalReachedMessages) {
+                    this.discordBot.sendToLogChannels(message);
+                }
             }
         }));
 
         // Admin commands
         registerTextHandler(new TextHandler("chat.type.admin", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.booleans.adminMessages) this.discordBot.sendToLogChannels(message);
+            if (this.config.minecraftToDiscord.chatChannels.adminMessages) {
+                this.discordBot.sendToChatChannels(message);
+            }
+            if (this.config.minecraftToDiscord.logChannels.adminMessages) {
+                this.discordBot.sendToLogChannels(message);
+            }
         }));
 
         // Player join server with new username
         registerTextHandler(new TextHandler("multiplayer.player.joined.renamed", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.booleans.joinAndLeaveMessages) {
+            if (this.config.minecraftToDiscord.chatChannels.joinAndLeaveMessages || this.config.minecraftToDiscord.logChannels.joinAndLeaveMessages) {
                 String newName = message.split("formerly known as ")[0];
                 newName = newName.substring(0, newName.length() - 2);
                 String oldName = message.split("formerly known as ")[1].split(" joined the game")[0];
                 oldName = oldName.substring(0, oldName.length() - 1);
                 message = this.config.minecraftToDiscord.messages.playerJoinedRenamed.replace("%new", adaptUsernameToDiscord(newName)).replace("%old", adaptUsernameToDiscord(oldName));
-                this.discordBot.sendToAllChannels(message);
+                if (this.config.minecraftToDiscord.chatChannels.joinAndLeaveMessages) {
+                    this.discordBot.sendToChatChannels(message);
+                }
+                if (this.config.minecraftToDiscord.logChannels.joinAndLeaveMessages) {
+                    this.discordBot.sendToLogChannels(message);
+                }
             }
         }));
 
         // Player join server
         registerTextHandler(new TextHandler("multiplayer.player.joined", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.booleans.joinAndLeaveMessages) {
+            if (this.config.minecraftToDiscord.chatChannels.joinAndLeaveMessages || this.config.minecraftToDiscord.logChannels.joinAndLeaveMessages) {
                 String name = message.split(" joined the game")[0];
                 message = this.config.minecraftToDiscord.messages.playerJoined.replace("%player", adaptUsernameToDiscord(name));
-                this.discordBot.sendToAllChannels(message);
+                if (this.config.minecraftToDiscord.chatChannels.joinAndLeaveMessages) {
+                    this.discordBot.sendToChatChannels(message);
+                }
+                if (this.config.minecraftToDiscord.logChannels.joinAndLeaveMessages) {
+                    this.discordBot.sendToLogChannels(message);
+                }
             }
         }));
 
         // Player leave server
         registerTextHandler(new TextHandler("multiplayer.player.left", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.booleans.joinAndLeaveMessages) {
+            if (this.config.minecraftToDiscord.chatChannels.joinAndLeaveMessages || this.config.minecraftToDiscord.logChannels.joinAndLeaveMessages) {
                 String name = message.split(" left the game")[0];
                 message = this.config.minecraftToDiscord.messages.playerLeft.replace("%player", adaptUsernameToDiscord(name));
-                this.discordBot.sendToAllChannels(message);
+                if (this.config.minecraftToDiscord.chatChannels.joinAndLeaveMessages) {
+                    this.discordBot.sendToChatChannels(message);
+                }
+                if (this.config.minecraftToDiscord.logChannels.joinAndLeaveMessages) {
+                    this.discordBot.sendToLogChannels(message);
+                }
             }
         }));
 
         // Death messages
         registerTextHandler(new TextHandler("death.", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.booleans.deathMessages) {
-                this.discordBot.sendToAllChannels(message);
+            if (this.config.minecraftToDiscord.chatChannels.deathMessages) {
+                this.discordBot.sendToChatChannels(message);
+            }
+            if (this.config.minecraftToDiscord.logChannels.deathMessages) {
+                this.discordBot.sendToLogChannels(message);
             }
         }));
     }
@@ -185,7 +246,7 @@ public final class MinecraftToDiscordHandler {
                 return;
             }
         }
-        if (this.config.minecraftToDiscord.booleans.enableDebugLogs) {
+        if (this.config.minecraftToDiscord.general.enableDebugLogs) {
             if (text instanceof TranslatableText) {
                 DiscordBot.LOGGER.error("[FDLink] Unhandled text \"{}\":{}", ((TranslatableText) text).getKey(), text.getString());
             } else {

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
@@ -119,15 +119,15 @@ public final class MinecraftToDiscordHandler {
         // Advancement challenge
         registerTextHandler(new TextHandler("chat.type.advancement.challenge", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.chatChannels.challengeCompletedMessages || this.config.minecraftToDiscord.logChannels.challengeCompletedMessages) {
+            if (this.config.minecraftToDiscord.chatChannels.challengeMessages || this.config.minecraftToDiscord.logChannels.challengeMessages) {
                 String[] args = message.split(" has completed the challenge ");
                 message = this.config.minecraftToDiscord.messages.advancementChallenge
                         .replace("%player", adaptUsernameToDiscord(args[0]))
                         .replace("%advancement", args[1]);
-                if (this.config.minecraftToDiscord.chatChannels.challengeCompletedMessages) {
+                if (this.config.minecraftToDiscord.chatChannels.challengeMessages) {
                     this.discordBot.sendToChatChannels(message);
                 }
-                if (this.config.minecraftToDiscord.logChannels.challengeCompletedMessages) {
+                if (this.config.minecraftToDiscord.logChannels.challengeMessages) {
                     this.discordBot.sendToLogChannels(message);
                 }
             }
@@ -136,15 +136,15 @@ public final class MinecraftToDiscordHandler {
         // Advancement goal
         registerTextHandler(new TextHandler("chat.type.advancement.goal", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (this.config.minecraftToDiscord.chatChannels.goalReachedMessages || this.config.minecraftToDiscord.logChannels.goalReachedMessages) {
+            if (this.config.minecraftToDiscord.chatChannels.goalMessages || this.config.minecraftToDiscord.logChannels.goalMessages) {
                 String[] args = message.split(" has reached the goal ");
                 message = this.config.minecraftToDiscord.messages.advancementGoal
                         .replace("%player", adaptUsernameToDiscord(args[0]))
                         .replace("%advancement", args[1]);
-                if (this.config.minecraftToDiscord.chatChannels.goalReachedMessages) {
+                if (this.config.minecraftToDiscord.chatChannels.goalMessages) {
                     this.discordBot.sendToChatChannels(message);
                 }
-                if (this.config.minecraftToDiscord.logChannels.goalReachedMessages) {
+                if (this.config.minecraftToDiscord.logChannels.goalMessages) {
                     this.discordBot.sendToLogChannels(message);
                 }
             }
@@ -213,10 +213,10 @@ public final class MinecraftToDiscordHandler {
         registerTextHandler(new TextHandler("death.", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
             if (this.config.minecraftToDiscord.chatChannels.deathMessages) {
-                this.discordBot.sendToChatChannels(message);
+                this.discordBot.sendToChatChannels(this.config.minecraftToDiscord.messages.deathMsgPrefix + message + this.config.minecraftToDiscord.messages.deathMsgPostfix);
             }
             if (this.config.minecraftToDiscord.logChannels.deathMessages) {
-                this.discordBot.sendToLogChannels(message);
+                this.discordBot.sendToLogChannels(this.config.minecraftToDiscord.messages.deathMsgPrefix + message + this.config.minecraftToDiscord.messages.deathMsgPostfix);
             }
         }));
     }
@@ -256,11 +256,11 @@ public final class MinecraftToDiscordHandler {
     }
 
     public static class TextHandler {
-        private final Class textType;
+        private final Class<?> textType;
         private final MinecraftToDiscordFunction minecraftToDiscordFunction;
         private String key;
 
-        public TextHandler(Class textType, MinecraftToDiscordFunction minecraftToDiscordFunction) {
+        public TextHandler(Class<?> textType, MinecraftToDiscordFunction minecraftToDiscordFunction) {
             this.textType = textType;
             this.minecraftToDiscordFunction = minecraftToDiscordFunction;
         }


### PR DESCRIPTION
I added two categories to the config file to give the user more fine grained control over what the bot sends to each channel, potentially significantly reducing clutter in the log channel (like user messages, which clutter the log when you just want quick info over who joined when for example) and also freeing up the chat channel from unnecessary server messages (like starting/stopping server, automatic periodic rcon messages i.e. for backup routines and more).

I needed to put a lot of if statements in the Handler which I did not really like, but the alternative would be rewriting a lot of stuff and that was even less appealing. The result is effectively deprecating the sendToAllChannels function. This can still be a useful function, I just did not see how without creating more bloated if statements.

The jar built without issues and everything seems to be working correctly on my own server.