### PR TITLE
Fix #78 and replace deprecated method

### DIFF
--- a/src/main/java/fr/arthurbambou/fdlink/FDLink.java
+++ b/src/main/java/fr/arthurbambou/fdlink/FDLink.java
@@ -8,10 +8,9 @@ import net.fabricmc.loader.api.FabricLoader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -82,7 +81,7 @@ public class FDLink implements DedicatedServerModInitializer {
 		}
 
 		public String loadConfig() {
-			try (FileReader fileReader = new FileReader(configFile)) {
+			try (InputStreamReader fileReader = new InputStreamReader(new FileInputStream(configFile), StandardCharsets.UTF_8)) {
 				config = gson.fromJson(fileReader, Config.class);
 				if (config.token == null) {
 					config.token = DefaultConfig.token;

--- a/src/main/java/fr/arthurbambou/fdlink/FDLink.java
+++ b/src/main/java/fr/arthurbambou/fdlink/FDLink.java
@@ -38,7 +38,7 @@ public class FDLink implements DedicatedServerModInitializer {
 	}
 
 	protected class ConfigManager {
-		private File CONFIG_PATH = FabricLoader.getInstance().getConfigDirectory();
+		private File CONFIG_PATH = FabricLoader.getInstance().getConfigDir().toFile();
 
 		private final Gson DEFAULT_GSON = new GsonBuilder().setPrettyPrinting().create();
 


### PR DESCRIPTION
- Fixes #78.
The problem was that FileReader uses the system encoding, in my case being `Cp1252`, which doesn't support russian characters.
- In addition, this pull request also uses `getConfigDir()` now, since the old way was deprecated (FabricMC/fabric-loader#162)