### PR TITLE
Added support for sending commands to a discord bot from in game.

### DIFF
--- a/src/main/java/fr/arthurbambou/fdlink/FDLink.java
+++ b/src/main/java/fr/arthurbambou/fdlink/FDLink.java
@@ -189,6 +189,7 @@ public class FDLink implements DedicatedServerModInitializer {
 		}
 
 		public class MinecraftToDiscordBooleans {
+			public boolean playerName = true;
 			public boolean serverStartingMessage = true;
 			public boolean serverStartMessage = true;
 			public boolean serverStopMessage = true;

--- a/src/main/java/fr/arthurbambou/fdlink/FDLink.java
+++ b/src/main/java/fr/arthurbambou/fdlink/FDLink.java
@@ -189,7 +189,7 @@ public class FDLink implements DedicatedServerModInitializer {
 		}
 
 		public class MinecraftToDiscordBooleans {
-			public boolean playerName = true;
+			public boolean playerNames = true;
 			public boolean serverStartingMessage = true;
 			public boolean serverStartMessage = true;
 			public boolean serverStopMessage = true;

--- a/src/main/java/fr/arthurbambou/fdlink/FDLink.java
+++ b/src/main/java/fr/arthurbambou/fdlink/FDLink.java
@@ -190,7 +190,7 @@ public class FDLink implements DedicatedServerModInitializer {
 
 		public class MinecraftToDiscordBooleans {
 			public boolean commandPrefix = "-";
-			public boolean playerNames = true;
+			public boolean allowDiscordCommands = true;
 			public boolean serverStartingMessage = true;
 			public boolean serverStartMessage = true;
 			public boolean serverStopMessage = true;

--- a/src/main/java/fr/arthurbambou/fdlink/FDLink.java
+++ b/src/main/java/fr/arthurbambou/fdlink/FDLink.java
@@ -189,6 +189,7 @@ public class FDLink implements DedicatedServerModInitializer {
 		}
 
 		public class MinecraftToDiscordBooleans {
+			public boolean commandPrefix = "-";
 			public boolean playerNames = true;
 			public boolean serverStartingMessage = true;
 			public boolean serverStartMessage = true;

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
@@ -31,10 +31,10 @@ public final class MinecraftToDiscordHandler {
         // Chat messages
         registerTextHandler(new TextHandler("chat.type.text", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            String smessage = message.substring(message.indexOf(">")+1);
+            String smessage = message.substring(message.indexOf(">")+2);
             smessage.trim();
-            if (this.config.minecraftToDiscord.booleans.allowDiscordCommands && smessage.substring(0,1) == this.config.minecraftToDiscord.booleans.commandPrefix) {
-                message=smessage;
+            if (this.config.minecraftToDiscord.booleans.allowDiscordCommands && smessage.charAt(0) == this.config.minecraftToDiscord.commandPrefix){
+                message = smessage;
             }
                 
             if (this.config.minecraftToDiscord.booleans.playerMessages) {

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
@@ -31,6 +31,12 @@ public final class MinecraftToDiscordHandler {
         // Chat messages
         registerTextHandler(new TextHandler("chat.type.text", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
+            if (!this.config.minecraftToDiscord.booleans.playerNames) {
+                String smessage = message.substring(message.indexOf(">")+1);
+                smessage.trim();
+                message=smessage
+            }
+                
             if (this.config.minecraftToDiscord.booleans.playerMessages) {
                 String playerName = message.split("> ")[0];
                 playerName = playerName.substring(1);

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
@@ -33,7 +33,7 @@ public final class MinecraftToDiscordHandler {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
             String smessage = message.substring(message.indexOf(">")+1);
             smessage.trim();
-            if (!this.config.minecraftToDiscord.booleans.playerNames && smessage.substring(0,1) == this.config.minecraftToDiscord.booleans.commandPrefix) {
+            if (this.config.minecraftToDiscord.booleans.allowDiscordCommands && smessage.substring(0,1) == this.config.minecraftToDiscord.booleans.commandPrefix) {
                 message=smessage;
             }
                 

--- a/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
+++ b/src/main/java/fr/arthurbambou/fdlink/discordstuff/todiscord/MinecraftToDiscordHandler.java
@@ -31,10 +31,10 @@ public final class MinecraftToDiscordHandler {
         // Chat messages
         registerTextHandler(new TextHandler("chat.type.text", text -> {
             String message = text.getString().replaceAll("§[b0931825467adcfeklmnor]", "");
-            if (!this.config.minecraftToDiscord.booleans.playerNames) {
-                String smessage = message.substring(message.indexOf(">")+1);
-                smessage.trim();
-                message=smessage
+            String smessage = message.substring(message.indexOf(">")+1);
+            smessage.trim();
+            if (!this.config.minecraftToDiscord.booleans.playerNames && smessage.substring(0,1) == this.config.minecraftToDiscord.booleans.commandPrefix) {
+                message=smessage;
             }
                 
             if (this.config.minecraftToDiscord.booleans.playerMessages) {


### PR DESCRIPTION
Added support for sending discord bot commands if enabled, with prefix configuration.

Added 2 config options:
- boolean allowDiscordCommands (default is true)
- char commandPrefix (default is "-")

Currently only supports 1 bot prefix.  
Required the receiving bot to not be ignoring bots for this to work. 
Good for music bots, will be using this myself to request music without tabbing out of the game.