### PR TITLE
Update the chat and log channel descriptions if configured to do so

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ After downloading the latest version, just drop the jar into the mods folder.
 1. Go to the [discord developer portal](https://discord.com/developers/applications) and register a new Application
 2. Register a new Bot for the application in the `<Bot>` tab to the left
 3. Toogle `<Server Members Intent>` to on under `<Priviledged Gateway Intents>` after creating a bot
-4. In the `<OAuth2>` Tab to the left, select the `<Bot>` option under `<Scopes>` and select the options `<View Channels>` and `<Send Messages>` 
+4. In the `<OAuth2>` Tab to the left, select the `<Bot>` option under `<Scopes>` and select the options `<View Channels>` and `<Send Messages>`
+    - Also select the `<Manage Channels>` permissions if you intend to enable custom channel descriptions.
 5. Copy the URL generated under `<Scopes>` and open it in a new tab to add the bot to your discord server
 
 ### Configuring Fabric-Discord-Link


### PR DESCRIPTION
The `customChannelDescription` option for chat and log channels has had no effect since the move to JDA. This change
re-enables the option so that, if enabled, the bot will attempt to set the chat or log channel topics every five
minutes.

This change also fixes a weakness in the scheduling logic. Due to the way integer division is used in the check, the
previous implementation would actually try to set the topic for every tick that happened to land on the 300th
second. This would mean up to 20 calls being attempted on a well running server, which immediately eats up the rate
limit. The new check instead uses a target time, after which the topic is updated and a new target time is set for five
minutes in the future.

The README.md has been updated to mention the `<Manage Channels>` permission that the bot requires for this feature. If
the permission is missing, a message is logged instructing the server admin to add the permission or else disable the
feature.