### PR TITLE
Fix calculation for uptime hours

### DIFF
--- a/common/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
+++ b/common/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordBot.java
@@ -166,7 +166,7 @@ public class DiscordBot {
 
             int totalUptimeSeconds = (int) (System.currentTimeMillis() - this.startTime) / 1000;
             final int uptimeD = totalUptimeSeconds / 86400;
-            final int uptimeH = (totalUptimeSeconds % 86400) / 24;
+            final int uptimeH = (totalUptimeSeconds % 86400) / 3600;
             final int uptimeM = (totalUptimeSeconds % 3600) / 60;
             final int uptimeS = totalUptimeSeconds % 60;
             final String topic = this.config.minecraftToDiscord.messages.channelDescription


### PR DESCRIPTION
E.g., when 3600 seconds have elapsed, `uptimeH` should be 1, not 150. And when 71400 seconds have elapsed, `uptimeH` should be 19, not 2975.