### PR TITLE
Fix wrong hour display in uptime command

### DIFF
--- a/common/src/main/java/fr/arthurbambou/fdlink/discord/Commands.java
+++ b/common/src/main/java/fr/arthurbambou/fdlink/discord/Commands.java
@@ -46,8 +46,8 @@ public enum Commands {
         int totalUptimeSeconds = (int) (System.currentTimeMillis() - startTime) / 1000;
 
         final int uptimeD = totalUptimeSeconds / 86400;
-        final int uptimeH = totalUptimeSeconds / 3600 ;
-        final int uptimeM = (totalUptimeSeconds % 3600) / 60;
+        final int uptimeH = (totalUptimeSeconds / 3600) % 24;
+        final int uptimeM = (totalUptimeSeconds / 60) % 60;
         final int uptimeS = totalUptimeSeconds % 60;
 
         messageCreateEvent.getChannel().sendMessage("Uptime: " + uptimeD + "d " + uptimeH + "h " + uptimeM + "m " + uptimeS + "s").submit();


### PR DESCRIPTION
It lacked a modulo, so the uptime could be something like `2d 48h 1m 12s`