### PR TITLE
Do not HTML-encoded the avatar URL

### DIFF
--- a/common/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordWebhook.java
+++ b/common/src/main/java/fr/arthurbambou/fdlink/discordstuff/DiscordWebhook.java
@@ -54,7 +54,7 @@ public class DiscordWebhook implements MessageSender {
             } catch (NullPointerException e) {
                 builder.setUsername("Could not get player username");
             }
-            builder.setAvatarUrl("https://crafatar.com/avatars/" + author.toString() + "?&amp;overlay");
+            builder.setAvatarUrl("https://crafatar.com/avatars/" + author.toString() + "?&overlay");
         }
 
         builder.setContent(message);


### PR DESCRIPTION
Since the ampersand was encoded as an HTML entity, Crafatar did not recognize the `overlay` parameter.