### PR TITLE
Change !playerlist message when there are no players online

### DIFF
--- a/common/src/main/java/fr/arthurbambou/fdlink/discord/Commands.java
+++ b/common/src/main/java/fr/arthurbambou/fdlink/discord/Commands.java
@@ -6,6 +6,8 @@ import fr.arthurbambou.fdlink.api.minecraft.PlayerEntity;
 import fr.arthurbambou.fdlink.discordstuff.MinecraftToDiscordHandler;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 
+import java.util.List;
+
 public enum Commands {
     playercount("Show the number of player on the server.",(minecraftServer, messageCreateEvent, startTime) -> {
         int playerNumber = minecraftServer.getPlayerCount();
@@ -15,14 +17,22 @@ public enum Commands {
     }),
     playerlist("Show the list of player on the server.",(minecraftServer, messageCreateEvent, startTime) -> {
         StringBuilder playerlist = new StringBuilder();
-        for (PlayerEntity playerEntity : minecraftServer.getPlayers()) {
-            playerlist.append(MessageHandler.adaptUsername(playerEntity.getPlayerName())).append("\n");
+
+        List<PlayerEntity> players = minecraftServer.getPlayers();
+
+        if (players.size() > 0) {
+            playerlist.append("Players:").append("\n");
+
+            for (int i = 0; i < players.size() - 1; i++) {
+                playerlist.append(MessageHandler.adaptUsername(players.get(i).getPlayerName())).append("\n");
+            }
+
+            playerlist.append(MessageHandler.adaptUsername(players.get(players.size() - 1).getPlayerName()));
+        } else {
+            playerlist.append("There are no players online.");
         }
-        if (playerlist.toString().endsWith("\n")) {
-            int a = playerlist.lastIndexOf("\n");
-            playerlist = new StringBuilder(playerlist.substring(0, a));
-        }
-        messageCreateEvent.getChannel().sendMessage("\n Players: \n" + playerlist).submit();
+
+        messageCreateEvent.getChannel().sendMessage(playerlist).submit();
         return false;
     }),
     status("Show various information about the server.", (minecraftServer, messageCreateEvent, startTime) -> {

--- a/common/src/main/java/fr/arthurbambou/fdlink/discord/Commands.java
+++ b/common/src/main/java/fr/arthurbambou/fdlink/discord/Commands.java
@@ -27,7 +27,7 @@ public enum Commands {
                 playerlist.append(MessageHandler.adaptUsername(players.get(i).getPlayerName())).append("\n");
             }
 
-            playerlist.append(MessageHandler.adaptUsername(players.get(players.size() - 1).getPlayerName()));
+            playerlist.append("- ").append(MessageHandler.adaptUsername(players.get(players.size() - 1).getPlayerName()));
         } else {
             playerlist.append("There are no players online.");
         }

--- a/common/src/main/java/fr/arthurbambou/fdlink/discord/Commands.java
+++ b/common/src/main/java/fr/arthurbambou/fdlink/discord/Commands.java
@@ -24,7 +24,7 @@ public enum Commands {
             playerlist.append("Players:").append("\n");
 
             for (int i = 0; i < players.size() - 1; i++) {
-                playerlist.append(MessageHandler.adaptUsername(players.get(i).getPlayerName())).append("\n");
+                playerlist.append("- ").append(MessageHandler.adaptUsername(players.get(i).getPlayerName())).append("\n");
             }
 
             playerlist.append("- ").append(MessageHandler.adaptUsername(players.get(players.size() - 1).getPlayerName()));


### PR DESCRIPTION
When there are no players online, `!playerlist` will now say "There are no players online." instead of responding with an empty player list. Also, the player list is now formatted like a list with dashes before each player name, like `!commands`.