### PR TITLE
Fix tellraw issue when console or datapacks use tellraw without slash

### DIFF
--- a/versions/fabric/1.16.5/src/main/java/fr/arthurbambou/fdlink/mixin_1_16/MixinTellRawCommand.java
+++ b/versions/fabric/1.16.5/src/main/java/fr/arthurbambou/fdlink/mixin_1_16/MixinTellRawCommand.java
@@ -47,7 +47,7 @@ public class MixinTellRawCommand {
         })).then(CommandManager.argument("targets", EntityArgumentType.players()).then(CommandManager.argument("message", TextArgumentType.text()).executes((commandContext) -> {
             int i = 0;
 
-            if (commandContext.getInput().replace("/tellraw ", "").startsWith("@a")) {
+            if (commandContext.getInput().replace("/tellraw ", "").startsWith("@a") || commandContext.getInput().replace("tellraw ", "").startsWith("@a")) {
                 try {
                     ServerCommandSource source = commandContext.getSource();
                     Text message = TextArgumentType.getTextArgument(commandContext, "message");


### PR DESCRIPTION
The Fabric Discord Link mod has the ability to enable/disable tellraw commands form propagating to the Discord; however, it doesn't currently account for the console or other sources such as datapacks calling tellraw without the preceeding slash. This commit simply adds an additional check to the command check to look for tellraw without the slash (in addition to the check with the slash). There is likely a more efficient way to write this code, but readability of the current solution is high.