### PR TITLE
Fix discord replies do being not send to Minecraft chat

### DIFF
--- a/api/src/main/java/fr/arthurbambou/fdlink/api/config/MessageConfig.java
+++ b/api/src/main/java/fr/arthurbambou/fdlink/api/config/MessageConfig.java
@@ -45,6 +45,7 @@ public class MessageConfig {
 
     public static class DiscordToMinecraft {
         public String message = "[%player] %message";
+        public String reply = "[%player] %message Reply to: [%replyPlayer] %replyMessage";
     }
 
     public static class DiscordOnly {

--- a/common/src/main/java/fr/arthurbambou/fdlink/discordstuff/MessageReceivedListener.java
+++ b/common/src/main/java/fr/arthurbambou/fdlink/discordstuff/MessageReceivedListener.java
@@ -20,7 +20,7 @@ public class MessageReceivedListener extends ListenerAdapter {
                 || this.discordBot.api.getSelfUser().getId().equals(event.getAuthor().getId())) return;
         if (!this.discordBot.hasChatChannels) return;
         if (!this.discordBot.config.mainConfig.chatChannels.contains(event.getChannel().getId())) return;
-        if (event.getMessage().getType() != MessageType.DEFAULT) return;
+        if ((event.getMessage().getType() != MessageType.DEFAULT) && (event.getMessage().getType() != MessageType.INLINE_REPLY)) return;
         if (!DiscordBot.lastMessageMs.isEmpty()) {
             if (event.getMessage().getContentRaw().equals(DiscordBot.lastMessageMs.get(0))) {
                 DiscordBot.lastMessageMs.remove(0);


### PR DESCRIPTION
* Fixes discord replies not being detected as a valid message to be send to Minecraft chat.

* Added a new config for Discord replies messages `[%player] %message Reply to: [%replyPlayer] %replyMessage`
located at messages.json->discordToMinecraft->reply

Fixes #175 